### PR TITLE
Feature/1344403: Consumer Experience: Swagger documentation shoud be according to the OpenAPI 3 format 

### DIFF
--- a/generators/node/basicGenerator.js
+++ b/generators/node/basicGenerator.js
@@ -1,4 +1,4 @@
-﻿'use strict';
+'use strict';
 
 /* eslint-disable no-console, no-process-exit, line-comment-position, sort-vars, no-eval */
 
@@ -460,7 +460,7 @@ const GenericSender = function(fun, delay, tolerance, dims, tags) {
     if (prefix) {
       urlStr += '/' + prefix;
     }
-    urlStr += '/api/submit/' + apiKey;
+    urlStr += '/api/submit';
 
     if (!_.isEmpty(dims)) {
       urlStr += '/dims/' + dims;
@@ -477,7 +477,7 @@ const GenericSender = function(fun, delay, tolerance, dims, tags) {
         request.post({
           url: urlStr,
           headers: {
-            'X-ApiKey': apiKey
+            'x-api-key': apiKey
           },
           body: evt,
           json: true,


### PR DESCRIPTION
Feature link- https://internal.almoctane.com/ui/?p=97002/8001#/entity-navigation?entityType=work_item&id=1344403

- Removed the API key from the URL
- Added **x-api-key** in request header
This PR involves changes required for the Swagger feature.
